### PR TITLE
Harden self-hosted deploy runner usage

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -9,9 +9,14 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: prod-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
-    runs-on: [self-hosted, k3s, deployer]
+    environment: production
+    runs-on: [self-hosted, k3s, deployer, kasperrt-ShotTimer]
     steps:
       - uses: actions/checkout@v5
       - run: .build/scripts/build-image.sh


### PR DESCRIPTION
## Summary\n- require the repo-specific self-hosted runner label for production deploys\n- attach deploy jobs to the production environment\n- add a production concurrency group so deploys for the same ref do not overlap\n\n## Tests\n- workflow-only change