### PR TITLE
Pass ShotTimer CORS env to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,12 @@ RUN pnpm prune --prod
 
 FROM node:${NODE_VERSION}-bookworm-slim AS runner
 WORKDIR /app
+ARG VITE_HOST
+ARG VITE_CORS
 ENV NODE_ENV=production
 ENV PORT=8080
+ENV VITE_HOST=${VITE_HOST}
+ENV VITE_CORS=${VITE_CORS}
 RUN npm install -g corepack@latest --force \
   && npm install -g pnpm@latest --force
 COPY --from=build /app/package.json /app/pnpm-lock.yaml ./


### PR DESCRIPTION
## Summary
- carry VITE_HOST and VITE_CORS build args into the runtime image
- fixes server-side CORS/SSE config after moving ShotTimer to https://shot.etys.no

## Test
- pnpm test -- --run