### PR TITLE
fix: pin current build dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "tailwindcss": "4.3.0",
     "tsx": "4.22.4",
     "typescript": "7.0.2",
-    "vite": ">=8.0.5",
+    "vite": "8.0.16",
     "vite-plugin-solid": "2.11.12",
     "vitest": "4.1.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         specifier: 7.0.2
         version: 7.0.2
       vite:
-        specifier: '>=8.0.5'
+        specifier: 8.0.16
         version: 8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
       vite-plugin-solid:
         specifier: 2.11.12


### PR DESCRIPTION
Keeps the production build on the current verified dependency release.