### PR TITLE
fix: align build dependency pin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   shell-quote: '>=1.8.5'
   undici: 7.29.0
   yaml: '>=2.8.3'
-  vite: '>=8.0.5'
+  vite: 8.0.16
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,4 +20,4 @@ overrides:
   shell-quote: ">=1.8.5"
   undici: "7.29.0"
   yaml: ">=2.8.3"
-  vite: ">=8.0.5"
+  vite: "8.0.16"


### PR DESCRIPTION
Keeps the workspace dependency configuration aligned with the verified production build.